### PR TITLE
Do not pass -z into systemd systems upon init

### DIFF
--- a/lib/env.c
+++ b/lib/env.c
@@ -902,7 +902,11 @@ err:
 int exec_init(const struct start_param *param)
 {
 	char cid[STR_SIZE];
-	char *argv[] = {"init", "-z", "      ", NULL};
+	if (is_systemd())
+		char *argv[] = {"init", NULL};
+	else
+		char *argv[] = {"init", "-z", "      ", NULL};
+	
 	char *envp[] = {"HOME=/", "TERM=linux", cid, NULL};
 	char **env;
 	int errcode = 0;


### PR DESCRIPTION
Because strange things can happen. Details here: https://github.com/systemd/systemd/issues/28184

While a systemd patch helps re-arrange arguments to work around the issue, -z isn't actually utilized by systemd, so there's no good reason to pass it.